### PR TITLE
Make nbviewer link point directly to this repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 The [Jupyter Notebooks](http://jupyter.org/) contained in this repository provide interactive figures 1, 4, and 5 from "Deblur rapidly resolves single-nucleotide community sequence patterns."
 
-We recommend viewing this Notebooks via [nbviewer](https://nbviewer.jupyter.org/).
+We recommend viewing these Notebooks [via nbviewer](http://nbviewer.jupyter.org/github/knightlab-analyses/deblur-manuscript/tree/master).


### PR DESCRIPTION
That means readers can click on the README and directly get active links for all the notebooks.

Also, fix small typo.